### PR TITLE
Use stdin

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,5 +1,4 @@
 import os
-import tempfile
 import subprocess
 
 from mcp.server.fastmcp import FastMCP
@@ -13,24 +12,18 @@ async def validate_libvirt_xml(xml_string: str) -> dict:
     Validates a libvirt XML string using virt-xml-validate.
     Returns the result of the validation.
     """
-    with tempfile.NamedTemporaryFile("w+", suffix=".xml", delete=False) as tmp:
-        tmp.write(xml_string)
-        tmp.flush()
-        tmp_path = tmp.name
-    try:
-        result = subprocess.run(
-            ["virt-xml-validate", tmp_path],
-            capture_output=True,
-            text=True,
-            check=False
-        )
-        return {
-            "returncode": result.returncode,
-            "stdout": result.stdout,
-            "stderr": result.stderr
-        }
-    finally:
-        os.remove(tmp_path)
+    result = subprocess.run(
+        ["virt-xml-validate", "-"],
+        input=xml_string,
+        capture_output=True,
+        text=True,
+        check=False
+    )
+    return {
+        "returncode": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr
+    }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Use stdin instead of a temporary file, as it is less error-prone, more
concise, more clean, and more efficient.
